### PR TITLE
ログイン時の遷移処理を修正

### DIFF
--- a/src/main/java/com/example/controller/CartController.java
+++ b/src/main/java/com/example/controller/CartController.java
@@ -1,6 +1,5 @@
 package com.example.controller;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 

--- a/src/main/java/com/example/controller/ConfirmOrderController.java
+++ b/src/main/java/com/example/controller/ConfirmOrderController.java
@@ -1,11 +1,14 @@
 package com.example.controller;
 
+import javax.servlet.http.HttpSession;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import com.example.domain.Customer;
 import com.example.domain.Order;
 import com.example.form.ExecOrderForm;
 import com.example.service.CartService;
@@ -16,6 +19,9 @@ public class ConfirmOrderController {
 
 	@Autowired
 	private CartService cartService;
+	
+	@Autowired
+	private HttpSession session;
 
 	/**
 	 * 注文用フォームを用意します.
@@ -28,11 +34,19 @@ public class ConfirmOrderController {
 	}
 
 	@RequestMapping("/confirmOrder")
-	public String toOrderConfirm(String orderId, Model model) {
-		Order order = cartService.getOrder(Integer.parseInt(orderId));
+	public String toOrderConfirm(Integer toOrderConfirm, Model model) {
+		// ログインされていない状態でははじく
+		Customer customer = (Customer)session.getAttribute("customer");
+		if(customer == null) {
+			session.setAttribute("toOrderConfirm", 1);
+			return "login";
+		}
+		
+		Integer orderId = cartService.getOrCreateOrderId(customer.getId());
+		
+		Order order = cartService.getOrder(orderId);
 		model.addAttribute("orderItemList", order.getOrderItemList());
 		model.addAttribute("order", order);
-		System.out.println(order);
 		return "order_confirm";
 	}
 

--- a/src/main/java/com/example/controller/LoginController.java
+++ b/src/main/java/com/example/controller/LoginController.java
@@ -1,8 +1,5 @@
 package com.example.controller;
 
-import java.util.Arrays;
-import java.util.List;
-
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
@@ -49,24 +46,21 @@ public class LoginController {
 	 */
 	@RequestMapping("/afterLogin")
 	public String afterLogin(@AuthenticationPrincipal LoginCustomer customer) {
+		session.setAttribute("customer", customer.getCustomer());
 		
 		// dummyCustomerIdがセットされていればcustomerIDの更新を行う
-		int dummyCustomerId = (int)session.getAttribute("dummyCustomerId");
-		if(dummyCustomerId != 0) {
+		Integer dummyCustomerId = (Integer)session.getAttribute("dummyCustomerId");
+		if(dummyCustomerId != null) {
 			int customerId = customer.getCustomer().getId();
 			session.removeAttribute("dummyCustomerId");
 			loginService.updateCustomerId(dummyCustomerId, customerId);
 		}
 		
-		String preUrl = (String)session.getAttribute("preUrl");
-		session.setAttribute("customer", customer.getCustomer());
-		if(preUrl == null) {
-			return "redirect:/show";
-		}
-		List<String> preUrlPathList = Arrays.asList(preUrl.split("/"));
-		if (preUrlPathList.contains("order_confirm")) {
-			session.removeAttribute("preUrl");
-			return "redirect:/confirm_order";
+		// 「注文画面へ」ボタンによってログイン画面に遷移していた場合は注文確認画面へ飛ばす
+		Integer toOrderConfirmFlag = (Integer)session.getAttribute("toOrderConfirm");
+		if(toOrderConfirmFlag != null) {
+			session.removeAttribute("toOrderConfirm");
+			return "redirect:/confirmOrder";			
 		}else {
 			return "redirect:/show";
 		}

--- a/src/main/resources/templates/cart_list.html
+++ b/src/main/resources/templates/cart_list.html
@@ -116,7 +116,7 @@
 				</div>
 				<div class="row order-confirm-btn">
 					<form method="post" th:action="@{/confirmOrder}">
-						<input type="hidden" name="orderId" th:value="${orderId}">
+						<input type="hidden" name="toOrderConfirm" value="1">
 						<button class="btn" type="submit">
 							<span>注文に進む</span>
 						</button>


### PR DESCRIPTION
ログイン時の遷移処理を注文ボタンを押した場合は、注文確認画面へ
それ以外の場合は商品一覧へ飛ばすように修正しました。